### PR TITLE
Miscellaneous improvements

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+    "trailingComma": "es5"
+}

--- a/src/components/EventSchedule/EventListVirtualized.tsx
+++ b/src/components/EventSchedule/EventListVirtualized.tsx
@@ -20,9 +20,7 @@ type VirtuosoProps<T> = {
 };
 
 export const EventListVirtualized = () => {
-    const { t } = useTranslation("EventSchedule", {
-        keyPrefix: "Groups",
-    });
+    const { t } = useTranslation("EventSchedule");
     const now = useNow();
     const { filtered = [] } = useEventFilter();
 
@@ -36,7 +34,7 @@ export const EventListVirtualized = () => {
             );
 
             if (expired.length) {
-                groups[t("expired")] = expired;
+                groups[t("Groups.expired")] = expired;
             }
 
             const groupCounts = map(groups, (values) => values.length);
@@ -55,36 +53,57 @@ export const EventListVirtualized = () => {
                     <EventSearch />
                 </Box>
             </Container>
-            <GroupedVirtuoso<EventScheduleItemModel>
-                groupCounts={groupCounts}
-                height={"100%"}
-                groupContent={(index) => (
-                    <Container key={groups[index]}>
-                        <Box pt={2} pb={2} pl={2} bgcolor={"background.paper"}>
-                            <Typography variant={"h5"}>
-                                {groups[index]}
-                            </Typography>
-                        </Box>
-                    </Container>
-                )}
-                itemContent={(index, groupIndex) => {
-                    const item = items[index];
-                    return (
-                        <Container
-                            sx={{
-                                pb: 1,
-                                opacity:
-                                    groups[groupIndex] === t("expired")
-                                        ? 0.4
-                                        : 1,
-                            }}
-                            key={item.id}
-                        >
-                            <EventScheduleItemCard event={item} />
+            {items.length === 0 ? (
+                <Box
+                    display={"flex"}
+                    flexDirection={"column"}
+                    flex={1}
+                    alignItems={"center"}
+                    justifyContent={"center"}
+                    gap={2}
+                >
+                    <Typography variant={"h5"}>
+                        {t("Search.no_results")}
+                    </Typography>
+                </Box>
+            ) : (
+                <GroupedVirtuoso<EventScheduleItemModel>
+                    groupCounts={groupCounts}
+                    height={"100%"}
+                    groupContent={(index) => (
+                        <Container key={groups[index]}>
+                            <Box
+                                pt={2}
+                                pb={2}
+                                pl={2}
+                                bgcolor={"background.paper"}
+                            >
+                                <Typography variant={"h5"}>
+                                    {groups[index]}
+                                </Typography>
+                            </Box>
                         </Container>
-                    );
-                }}
-            />
+                    )}
+                    itemContent={(index, groupIndex) => {
+                        const item = items[index];
+                        return (
+                            <Container
+                                sx={{
+                                    pb: 1,
+                                    opacity:
+                                        groups[groupIndex] ===
+                                        t("Groups.expired")
+                                            ? 0.4
+                                            : 1,
+                                }}
+                                key={item.id}
+                            >
+                                <EventScheduleItemCard event={item} />
+                            </Container>
+                        );
+                    }}
+                />
+            )}
         </Box>
     );
 };

--- a/src/components/EventSchedule/EventListVirtualized.tsx
+++ b/src/components/EventSchedule/EventListVirtualized.tsx
@@ -67,10 +67,19 @@ export const EventListVirtualized = () => {
                         </Box>
                     </Container>
                 )}
-                itemContent={(index) => {
+                itemContent={(index, groupIndex) => {
                     const item = items[index];
                     return (
-                        <Container sx={{ pb: 1 }} key={item.id}>
+                        <Container
+                            sx={{
+                                pb: 1,
+                                opacity:
+                                    groups[groupIndex] === t("expired")
+                                        ? 0.4
+                                        : 1,
+                            }}
+                            key={item.id}
+                        >
                             <EventScheduleItemCard event={item} />
                         </Container>
                     );

--- a/src/components/EventSchedule/EventListVirtualized.tsx
+++ b/src/components/EventSchedule/EventListVirtualized.tsx
@@ -1,5 +1,6 @@
-import { GroupedVirtuoso } from "react-virtuoso";
 import { useMemo } from "react";
+import { GroupedVirtuoso } from "react-virtuoso";
+import { useTranslation } from "react-i18next";
 import { flatMap, groupBy, keys, map, partition, values } from "lodash";
 import { Box, Container, Typography } from "@mui/material";
 import dayjs from "dayjs";
@@ -19,6 +20,9 @@ type VirtuosoProps<T> = {
 };
 
 export const EventListVirtualized = () => {
+    const { t } = useTranslation("EventSchedule", {
+        keyPrefix: "Groups",
+    });
     const now = useNow();
     const { filtered = [] } = useEventFilter();
 
@@ -32,7 +36,7 @@ export const EventListVirtualized = () => {
             );
 
             if (expired.length) {
-                groups["Expired"] = expired;
+                groups[t("expired")] = expired;
             }
 
             const groupCounts = map(groups, (values) => values.length);

--- a/src/components/EventSchedule/EventListVirtualized.tsx
+++ b/src/components/EventSchedule/EventListVirtualized.tsx
@@ -31,7 +31,9 @@ export const EventListVirtualized = () => {
                 dayjs(it.startTime).format("LL")
             );
 
-            groups["Expired"] = expired;
+            if (expired.length) {
+                groups["Expired"] = expired;
+            }
 
             const groupCounts = map(groups, (values) => values.length);
 

--- a/src/components/EventSchedule/EventScheduleItemCard.tsx
+++ b/src/components/EventSchedule/EventScheduleItemCard.tsx
@@ -11,6 +11,7 @@ import { useLocalizedEvent } from "../../hooks/useLocalizedEvent";
 import { useEventSubtitle } from "../../hooks/useEventSubtitle";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { toggleEventBookmark } from "../../store/bookmarks";
+import { useEventState } from "../../hooks/useEventState";
 
 import {
     BookmarkedFilterChip,
@@ -33,6 +34,7 @@ export const EventScheduleItemCard = ({
     event,
 }: EventScheduleItemCardProps) => {
     const dispatch = useAppDispatch();
+    const state = useEventState(event);
     const isBookmarked = useAppSelector((state) =>
         state.bookmarks.events.includes(event.id)
     );
@@ -45,7 +47,7 @@ export const EventScheduleItemCard = ({
     }, [dispatch]);
 
     return (
-        <Card>
+        <Card sx={{ border: state === "current" ? 1 : 0 }}>
             <CardHeader
                 title={name}
                 subheader={subheader}

--- a/src/components/EventSchedule/Search/DayFilterMenu.tsx
+++ b/src/components/EventSchedule/Search/DayFilterMenu.tsx
@@ -7,6 +7,7 @@ import {
     MenuItem,
     MenuList,
     Popover,
+    useTheme,
 } from "@mui/material";
 import {
     bindPopover,
@@ -24,6 +25,7 @@ import DayIcon from "~icons/mdi/calendar-today";
 import CheckIcon from "~icons/ic/round-check";
 
 export const DayFilterMenu = () => {
+    const theme = useTheme();
     const { t } = useTranslation("EventSchedule", { keyPrefix: "Search" });
 
     const { toggleDate, original, filters } = useEventFilter();
@@ -39,7 +41,14 @@ export const DayFilterMenu = () => {
         [original]
     );
     return (
-        <Button {...bindToggle(popover)}>
+        <Button
+            {...bindToggle(popover)}
+            sx={{
+                color: filters.dates.length
+                    ? theme.palette.warning.main
+                    : undefined,
+            }}
+        >
             <Badge badgeContent={filters.dates.length} color={"warning"}>
                 <DayIcon fontSize={"1.4rem"} />
             </Badge>

--- a/src/components/EventSchedule/Search/EventSearch.tsx
+++ b/src/components/EventSchedule/Search/EventSearch.tsx
@@ -48,18 +48,20 @@ export const EventSearch = () => {
                         variant={"text"}
                         color={"inherit"}
                     >
-                        <Button
-                            onClick={() => {
-                                setSearch("");
-                            }}
-                            disabled={filters.search.length === 0}
-                        >
-                            <ClearIcon fontSize={"1.4rem"} />
-                        </Button>
-                        <ResetButton />
+                        {filters.search.length !== 0 && (
+                            <Button
+                                onClick={() => {
+                                    setSearch("");
+                                }}
+                                color={"error"}
+                            >
+                                <ClearIcon fontSize={"1.4rem"} />
+                            </Button>
+                        )}
                         <BookmarkFilterButton />
                         <RoomFilterMenu />
                         <DayFilterMenu />
+                        <ResetButton />
                     </ButtonGroup>
                 ),
             }}

--- a/src/components/EventSchedule/Search/ResetButton.tsx
+++ b/src/components/EventSchedule/Search/ResetButton.tsx
@@ -9,6 +9,7 @@ export const ResetButton = () => {
     const { filters, reset } = useEventFilter();
     return (
         <Button
+            color={"error"}
             disabled={isEqual(filters, defaultEventFilters)}
             onClick={reset}
         >

--- a/src/components/EventSchedule/Search/RoomFilterMenu.tsx
+++ b/src/components/EventSchedule/Search/RoomFilterMenu.tsx
@@ -1,4 +1,5 @@
 import {
+    Badge,
     Button,
     ListItemIcon,
     ListItemText,
@@ -6,6 +7,7 @@ import {
     MenuItem,
     MenuList,
     Popover,
+    useTheme,
 } from "@mui/material";
 import {
     bindPopover,
@@ -22,6 +24,7 @@ import CheckIcon from "~icons/ic/round-check";
 import RoomIcon from "~icons/ic/baseline-room";
 
 export const RoomFilterMenu = () => {
+    const theme = useTheme();
     const { t, i18n } = useTranslation("EventSchedule", {
         keyPrefix: "Search",
     });
@@ -48,8 +51,17 @@ export const RoomFilterMenu = () => {
         return null;
     }
     return (
-        <Button {...bindToggle(popover)}>
-            <RoomIcon fontSize={"1.4rem"} />
+        <Button
+            {...bindToggle(popover)}
+            sx={{
+                color: filters.rooms.length
+                    ? theme.palette.warning.main
+                    : undefined,
+            }}
+        >
+            <Badge badgeContent={filters.rooms.length} color={"warning"}>
+                <RoomIcon fontSize={"1.4rem"} />
+            </Badge>
             <Popover
                 {...bindPopover(popover)}
                 anchorOrigin={{

--- a/src/components/Settings/LanguageSettings.tsx
+++ b/src/components/Settings/LanguageSettings.tsx
@@ -24,9 +24,7 @@ export const LanguageSettings = () => {
                 <ListItemIcon sx={{ pr: 2 }}>
                     <Avatar>🇬🇧</Avatar>
                 </ListItemIcon>
-                <ListItemText
-                    primary={t("LanguageSettings.english")}
-                ></ListItemText>
+                <ListItemText primary="English"></ListItemText>
             </MenuItem>
             <MenuItem
                 selected={locale === "pl"}
@@ -35,9 +33,7 @@ export const LanguageSettings = () => {
                 <ListItemIcon sx={{ pr: 2 }}>
                     <Avatar>🇵🇱</Avatar>
                 </ListItemIcon>
-                <ListItemText
-                    primary={t("LanguageSettings.polish")}
-                ></ListItemText>
+                <ListItemText primary="Polski"></ListItemText>
             </MenuItem>
 
             <MenuItem
@@ -47,9 +43,7 @@ export const LanguageSettings = () => {
                 <ListItemIcon sx={{ pr: 2 }}>
                     <Avatar>🇳🇱</Avatar>
                 </ListItemIcon>
-                <ListItemText
-                    primary={t("LanguageSettings.dutch")}
-                ></ListItemText>
+                <ListItemText primary="Nederlands"></ListItemText>
             </MenuItem>
         </>
     );

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -66,10 +66,7 @@
     },
     "Settings": {
         "LanguageSettings": {
-            "title": "Language & Locale Selection",
-            "english": "English",
-            "polish": "Polish",
-            "dutch": "Dutch"
+            "title": "Language & Locale Selection"
         },
         "TimeTravelSettings": {
             "title": "Time Travel",

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -21,6 +21,9 @@
         "EventListVirtualized": {
             "header": "$t(EventSchedule:title)"
         },
+        "Groups": {
+            "expired": "Expired"
+        },
         "Overview": {
             "title": "Up Next",
             "current": {

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -10,7 +10,8 @@
             "search_label": "Search the schedule",
             "search_placeholder": "Opening Ceremony . . .",
             "date_subheader": "Filter by date",
-            "room_subheader": "Filter by room"
+            "room_subheader": "Filter by room",
+            "no_results": "No results"
         },
         "title": "Event Schedule",
         "EventChips": {

--- a/src/i18n/translations/nl.json
+++ b/src/i18n/translations/nl.json
@@ -59,10 +59,7 @@
     },
     "Settings": {
         "LanguageSettings": {
-            "title": "Taal- en Lokalisatieinstellingen",
-            "english": "Engels",
-            "polish": "Pools",
-            "dutch": "Nederlands"
+            "title": "Taal- en Lokalisatieinstellingen"
         },
         "TimeTravelSettings": {
             "title": "Tijdreizen",

--- a/src/i18n/translations/pl.json
+++ b/src/i18n/translations/pl.json
@@ -21,6 +21,9 @@
         "EventListVirtualized": {
             "header": "$t(EventSchedule:title)"
         },
+        "Groups": {
+            "expired": "Zakończone"
+        },
         "Overview": {
             "title": "Ne",
             "current": {

--- a/src/i18n/translations/pl.json
+++ b/src/i18n/translations/pl.json
@@ -6,6 +6,12 @@
         }
     },
     "EventSchedule": {
+        "Search": {
+            "search_label": "Szukaj punktów programu",
+            "search_placeholder": "Oficjalne Rozpoczęcie . . .",
+            "date_subheader": "Filtruj po dacie",
+            "room_subheader": "Filtruj po sali"
+        },
         "title": "Punkty programu",
         "EventChips": {
             "BookmarkChip": {
@@ -34,7 +40,8 @@
         },
         "useEventSubtitle": {
             "starting": "Od godziny {{start}} ({{time}})",
-            "taking_place": "Obecnie odbywają się"
+            "taking_place": "Obecnie odbywają się",
+            "expired": "To wydarzenie już się odbyło"
         }
     },
     "Home": {
@@ -71,5 +78,17 @@
                 "label": "Zmień czas"
             }
         }
+    },
+    "EventChips": {
+        "signup_required": "Wymagane zapisanie się",
+        "signup_required_tooltip": "Możesz dołączyć do tego wydarzenia tylko po zapisaniu się na stronie",
+        "organizer_tooltip": "To jeden z organizatorów tego wydarzenia"
+    },
+    "LoadingIndicator": {
+        "loading": "Proszę czekać, trwa ładowanie . . ."
+    },
+    "ServiceWorker": {
+        "update_available_title": "Dostępna jest nowa wersja",
+        "update_available_subtitle": "Zaktualizuj do najnowszej wersji, aby być na bieżąco z Gdakonem"
     }
 }

--- a/src/i18n/translations/pl.json
+++ b/src/i18n/translations/pl.json
@@ -10,7 +10,8 @@
             "search_label": "Szukaj punktów programu",
             "search_placeholder": "Oficjalne Rozpoczęcie . . .",
             "date_subheader": "Filtruj po dacie",
-            "room_subheader": "Filtruj po sali"
+            "room_subheader": "Filtruj po sali",
+            "no_results": "Brak wyników"
         },
         "title": "Punkty programu",
         "EventChips": {

--- a/src/i18n/translations/pl.json
+++ b/src/i18n/translations/pl.json
@@ -44,7 +44,7 @@
         },
         "useEventSubtitle": {
             "starting": "Od godziny {{start}} ({{time}})",
-            "taking_place": "Obecnie odbywają się",
+            "taking_place": "Właśnie trwa",
             "expired": "To wydarzenie już się odbyło"
         }
     },

--- a/src/i18n/translations/pl.json
+++ b/src/i18n/translations/pl.json
@@ -59,10 +59,7 @@
     },
     "Settings": {
         "LanguageSettings": {
-            "title": "Wybór języka i lokalizacji",
-            "english": "Angielski",
-            "polish": "Polski",
-            "dutch": "Holenderski"
+            "title": "Wybór języka i lokalizacji"
         },
         "TimeTravelSettings": {
             "title": "Podróż w czasie",


### PR DESCRIPTION
Some of the motives:
- Move reset all filters button to the end - Better represents the scope of the button's action i.e. affecting both text input and filter buttons.
- Unify active state for all filters - Better represent active filters by making all active ones styled the same - orange.
- Don't translate language names - More intuitive and useful, especially when some systems don't display the accompanying flag emoji as an actual flag.
- Make buttons for clearing input and filters red - Better differentiate them from non-destructive buttons like regular inactive filters.

and more.